### PR TITLE
Fix slideshow image positioning

### DIFF
--- a/components/Tickets/BaseSlide.vue
+++ b/components/Tickets/BaseSlide.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="w-full max-w-lg px-5 py-20 font-mono md:px-10 md:max-w-lg" @click.stop>
-    <div class="w-full shadow-xl">
-      <slot />
-    </div>
+  <div class="flex items-center justify-center w-full max-w-lg px-5 py-20 font-mono h-[90vh] md:px-10 md:max-w-lg" @click.stop>
+    <slot />
   </div>
 </template>

--- a/components/Tickets/ImageSlide.vue
+++ b/components/Tickets/ImageSlide.vue
@@ -1,6 +1,6 @@
 <template>
-  <CoversBaseSlide>
-    <div class="flex flex-col justify-center w-full gap-4 cursor-grab aspect-square">
+  <TicketsBaseSlide>
+    <div class="flex flex-col items-center justify-center w-full gap-4 cursor-grab aspect-square">
       <NuxtImg
         class="bg-gray-500"
         provider="strapi"
@@ -9,7 +9,7 @@
         :alt="imageAlt"
       />
     </div>
-  </CoversBaseSlide>
+  </TicketsBaseSlide>
 </template>
 
 <script setup lang="ts">

--- a/components/Tickets/ImageSlide.vue
+++ b/components/Tickets/ImageSlide.vue
@@ -1,14 +1,12 @@
 <template>
   <TicketsBaseSlide>
-    <div class="flex flex-col items-center justify-center w-full gap-4 cursor-grab aspect-square">
-      <NuxtImg
-        class="bg-gray-500"
-        provider="strapi"
-        :modifiers="{ breakpoint: 'large' }"
-        :src="imageUrl"
-        :alt="imageAlt"
-      />
-    </div>
+    <NuxtImg
+      class="bg-gray-500"
+      provider="strapi"
+      :modifiers="{ breakpoint: 'large' }"
+      :src="imageUrl"
+      :alt="imageAlt"
+    />
   </TicketsBaseSlide>
 </template>
 


### PR DESCRIPTION
This PR fixes a rendering issue where using non-square images in the ticket-slideshow would cause other slides to be rendered off center in the viewport.