### PR TITLE
Dynamic slides

### DIFF
--- a/components/Tickets/Show.vue
+++ b/components/Tickets/Show.vue
@@ -11,28 +11,9 @@
         class="relative w-full sm:mb-10"
         @click="exit"
       >
-        <slide key="intro" @click="exit">
-          <TicketsIntroSlide :intro-slide="slideshow.intro_slide" />
-        </slide>
-
-        <slide
-          v-for="slide in slideshow.image_slides"
-          :key="slide.id"
-          class="flex justify-center h-full"
-        >
-          <TicketsImageSlide
-            :image-url="slide.image.data.attributes.hash+slide.image.data.attributes.ext"
-            :image-alt="slide.image.data.attributes.alternativeText"
-          />
-        </slide>
-
-        <slide
-          v-for="slide in slideshow.video_slides"
-          :key="slide.id"
-          class="flex justify-center h-full"
-        >
-          <TicketsVideoSlide :youtube-id="slide.youtube_id" />
-        </slide>
+        <Slide v-for="slide in slideshow.slides" :key="slide.id" @click="exit">
+          <TicketsSlideRenderer :slide="slide" />
+        </Slide>
       </Carousel>
     </Transition>
 

--- a/components/Tickets/Show.vue
+++ b/components/Tickets/Show.vue
@@ -1,16 +1,14 @@
 <template>
-  <div v-if="slideshow !== null && slideshow !== undefined" class="fixed inset-0 z-20 flex items-center justify-center bg-black/80" @click="exit">
+  <div v-if="slideshow" class="fixed inset-0 z-20 flex items-center justify-center bg-black/80" @click="exit">
     <Transition
       enter-active-class="transition duration-500 ease-out delay-300 transform-gpu"
       enter-from-class="translate-y-20 opacity-0"
       enter-to-class="opacity-100"
     >
       <Carousel
-        v-if="appearShow && slideshow !== null && slideshow !== undefined"
+        v-if="appearShow"
         ref="swiper"
         class="relative w-full sm:mb-10"
-        :mouse-drag="canDragSlides"
-        :touch-drag="canDragSlides"
         @click="exit"
       >
         <slide key="intro" @click="exit">
@@ -78,14 +76,4 @@ const currentSlide = computed(() => {
 const exit = () => {
   emit('close')
 }
-
-// disable drag while transitions are active to fix buggy UI
-const canDragSlides = ref(false)
-onMounted(() => {
-  setTimeout(() => {
-    canDragSlides.value = true
-  }, 500)
-})
-
-useScrollLock()
 </script>

--- a/components/Tickets/SlideRenderer.vue
+++ b/components/Tickets/SlideRenderer.vue
@@ -1,0 +1,22 @@
+<template>
+  <TicketsIntroSlide v-if="slide.__component === 'ticket-slideshow.intro-slide'" :intro-slide="slide" />
+  <TicketsVideoSlide v-else-if="slide.__component === 'ticket-slideshow.video-slide'" :video-slide="slide" />
+  <TicketsImageSlide
+    v-else-if="slide.__component === 'ticket-slideshow.image-slide'"
+    :image-url="slide.image.data.attributes.hash+slide.image.data.attributes.ext"
+    :image-alt="slide.image.data.attributes.alternativeText"
+  />
+  <TicketsBaseSlide v-else>
+    <p class="text-white">
+      Could not find component for "{{ slide.__component }}"
+    </p>
+  </TicketsBaseSlide>
+</template>
+
+<script setup lang="ts">
+import 'vue3-carousel/dist/carousel.css'
+import type { SlideComponentDefinition } from '~/types/TicketSlideshow'
+const { slide } = defineProps<{
+  slide: SlideComponentDefinition
+}>()
+</script>

--- a/composables/useCMSData.ts
+++ b/composables/useCMSData.ts
@@ -33,7 +33,10 @@ export const useCMSData = (doCacheData: boolean) => {
             image_slides: {
               populate: ['image']
             },
-            video_slides: true
+            video_slides: true,
+            slides: {
+              populate: '*'
+            }
           }
         }
       }

--- a/types/TicketSlideshow.ts
+++ b/types/TicketSlideshow.ts
@@ -18,7 +18,5 @@ export interface TicketsVideoSlide {
 }
 
 export interface TicketsSlideshow {
-  intro_slide: TicketsIntroSlide
-  image_slides: TicketsImageSlide[]
-  video_slides: TicketsVideoSlide[]
+  slides: SlideComponentDefinition[]
 }

--- a/types/TicketSlideshow.ts
+++ b/types/TicketSlideshow.ts
@@ -1,3 +1,8 @@
+export interface SlideComponentDefinition {
+  __component: string
+  id: number
+}
+
 export interface TicketsIntroSlide {
   title: string
   subtitle: string


### PR DESCRIPTION
This PR adds dynamic slides to the new slideshow system.

It allows for more flexible management of slides, as various slide typed can appear in any order in the slideshow. The `Slideshows` collection in strapi has also been updated with this new structure. 

Preview the changes at:
- [strapi `slideshows` collection](https://strapi.orkide.world/admin/content-manager/collectionType/api::slideshow.slideshow/1)
- [preview website deployment](https://dynamic-slides.orkide-frontend.pages.dev/)

<img width="601" alt="Screenshot 2024-02-13 at 08 39 24" src="https://github.com/kakka0903/orkide-frontend/assets/49387825/4e266fbf-d25d-45b8-9769-46ed7423722b">


